### PR TITLE
Fix for M34WQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,16 @@ A script to configure Gigabyte monitor attributes (brightness, contrast, kvm swi
 
 ## Usage
 ```text
-usage: monitor.py [-h] [-b [0-100]] [-c [0-100]] [-s [0-10]] [-lb [0-10]] [-kvm [0-1]] [-cm [0-3]] [--rgb-red [0-100]] [--rgb-green [0-100]]
-                  [--rgb-blue [0-100]]
-
-Set properties of gigabyte monitors.
-
-options:
-  -h, --help            show this help message and exit
-  -b [0-100], --brightness [0-100]
-  -c [0-100], --contrast [0-100]
-  -s [0-10], --sharpness [0-10]
-  -lb [0-10], --low-blue-light [0-10]
-  -kvm [0-1], --kvm-switch [0-1]
-  -cm [0-3], --color-mode [0-3]
-  --rgb-red [0-100]
-  --rgb-green [0-100]
-  --rgb-blue [0-100]
+usage: monitor.py [-h] -p
+                  {brightness,contrast,sharpness,low-blue-light,kvm-switch,colour-mode,rgb-red,rgb-green,rgb-blue}
+                  -v [0-255]
 ```
 
 ## Dependencies
 * [pyhidapi](https://github.com/apmorton/pyhidapi) (Make sure to install the hidapi shared library)
 
 ## Caveats
-- Was only tested under macOS, with a M34WQ monitor.
+- Was only tested under Windows 11, with a M27U monitor.
 - The supplied script supports only writing attributes and not reading them.
 - Only works from the currently active KVM input device.
 
@@ -37,4 +24,3 @@ The script is based on the following works:
 - @kelvie at https://github.com/kelvie/gbmonctl
 - @P403n1x87 at https://github.com/P403n1x87/m27q
 - @MarekPrzydanek at https://github.com/MarekPrzydanek/GigabyteMonitorController
-- @WildFireFlum at https://github.com/WildFireFlum/gbmonitor

--- a/README.md
+++ b/README.md
@@ -6,16 +6,29 @@ A script to configure Gigabyte monitor attributes (brightness, contrast, kvm swi
 
 ## Usage
 ```text
-usage: monitor.py [-h] -p
-                  {brightness,contrast,sharpness,low-blue-light,kvm-switch,colour-mode,rgb-red,rgb-green,rgb-blue}
-                  -v [0-255]
+usage: monitor.py [-h] [-b [0-100]] [-c [0-100]] [-s [0-10]] [-lb [0-10]] [-kvm [0-1]] [-cm [0-3]] [--rgb-red [0-100]] [--rgb-green [0-100]]
+                  [--rgb-blue [0-100]]
+
+Set properties of gigabyte monitors.
+
+options:
+  -h, --help            show this help message and exit
+  -b [0-100], --brightness [0-100]
+  -c [0-100], --contrast [0-100]
+  -s [0-10], --sharpness [0-10]
+  -lb [0-10], --low-blue-light [0-10]
+  -kvm [0-1], --kvm-switch [0-1]
+  -cm [0-3], --color-mode [0-3]
+  --rgb-red [0-100]
+  --rgb-green [0-100]
+  --rgb-blue [0-100]
 ```
 
 ## Dependencies
 * [pyhidapi](https://github.com/apmorton/pyhidapi) (Make sure to install the hidapi shared library)
 
 ## Caveats
-- Was only tested under Windows 11, with a M27U monitor.
+- Was only tested under macOS, with a M34WQ monitor.
 - The supplied script supports only writing attributes and not reading them.
 - Only works from the currently active KVM input device.
 
@@ -24,3 +37,4 @@ The script is based on the following works:
 - @kelvie at https://github.com/kelvie/gbmonctl
 - @P403n1x87 at https://github.com/P403n1x87/m27q
 - @MarekPrzydanek at https://github.com/MarekPrzydanek/GigabyteMonitorController
+- @WildFireFlum at https://github.com/WildFireFlum/gbmonitor

--- a/monitor.py
+++ b/monitor.py
@@ -160,12 +160,12 @@ def ranged_int(min: int, max: int):
 
 def main():
     monitor = Monitor()
-    parser = argparse.ArgumentParser(description="Set monitor property.")
+    parser = argparse.ArgumentParser(description="Set properties of gigabyte monitors.")
 
     # Generate options from configurable properties
     for prop in monitor.configurable_properties.values():
         name = (f"-{prop.abbr}", f"--{prop.name}") if prop.abbr is not None else (f"--{prop.name}",)
-        parser.add_argument(*name, type=ranged_int(*prop.range))
+        parser.add_argument(*name, type=ranged_int(*prop.range), metavar=f"[{prop.range[0]}-{prop.range[1]}]")
     args = parser.parse_args()
 
     # Set property for each supplied argument

--- a/monitor.py
+++ b/monitor.py
@@ -1,11 +1,8 @@
-#!/usr/bin/env python3
-
-import argparse
-import time
-from dataclasses import dataclass
-from typing import Optional, Tuple
-
 import hid
+import argparse
+
+from dataclasses import dataclass
+from typing import Tuple
 
 
 @dataclass
@@ -13,82 +10,38 @@ class MonitorProperty:
     """
     A configurable monitor property
     """
-
     name: str
     value: int
     range: Tuple[int, int]
-    abbr: Optional[str] = None
-    description: str = ""
+    description: str = ''
 
 
 class Monitor:
     """
     This class sets configurable monitor properties
     """
-
-    VID = 0x0BDA
+    VID = 0x0bda
     PID = 0x1100
 
     @property
     def configurable_properties(self):
         return {
-            "brightness": MonitorProperty(
-                name="brightness",
-                abbr="b",
-                range=tuple((0, 100)),
-                value=0x10,
-            ),
-            "contrast": MonitorProperty(
-                name="contrast",
-                abbr="c",
-                range=tuple((0, 100)),
-                value=0x12,
-            ),
-            "sharpness": MonitorProperty(
-                name="sharpness",
-                abbr="s",
-                range=tuple((0, 10)),
-                value=0x87,
-            ),
-            "low_blue_light": MonitorProperty(
-                name="low-blue-light",
-                abbr="lb",
-                range=tuple((0, 10)),
-                value=0xE00B,
-                description="Blue light reduction. 0 means no reduction.",
-            ),
-            "kvm_switch": MonitorProperty(
-                name="kvm-switch",
-                abbr="kvm",
-                range=tuple((0, 1)),
-                value=0xE069,
-                description="Switch KVM to device 0 or 1",
-            ),
-            "color_mode": MonitorProperty(
-                name="color-mode",
-                abbr="cm",
-                range=tuple((0, 3)),
-                value=0xE003,
-                description="0 is cool, 1 is normal, 2 is warm, 3 is user-defined.",
-            ),
-            "rgb_red": MonitorProperty(
-                name="rgb-red",
-                range=tuple((0, 100)),
-                value=0xE004,
-                description="Red value -- only works if colour-mode is set to 3",
-            ),
-            "rgb_green": MonitorProperty(
-                name="rgb-green",
-                range=tuple((0, 100)),
-                value=0xE005,
-                description="Green value -- only works if colour-mode is set to 3",
-            ),
-            "rgb_blue": MonitorProperty(
-                name="rgb-blue",
-                range=tuple((0, 100)),
-                value=0xE006,
-                description="Blue value -- only works if colour-mode is set to 3",
-            ),
+            "brightness": MonitorProperty(name="brightness", range=tuple((0, 100)), value=0x10, ),
+
+            "contrast": MonitorProperty(name="contrast", range=tuple((0, 100)), value=0x12, ),
+            "sharpness": MonitorProperty(name="sharpness", range=tuple((0, 10)), value=0x87, ),
+            "low-blue-light": MonitorProperty(name="low-blue-light", range=tuple((0, 10)), value=0xe00b,
+                                              description="Blue light reduction. 0 means no reduction.", ),
+            "kvm-switch": MonitorProperty(name="kvm-switch", range=tuple((0, 1)), value=0xe069,
+                                          description="Switch KVM to device 0 or 1", ),
+            "colour-mode": MonitorProperty(name="colour-mode", range=tuple((0, 3)), value=0xe003,
+                                           description="0 is cool, 1 is normal, 2 is warm, 3 is user-defined.", ),
+            "rgb-red": MonitorProperty(name="rgb-red", range=tuple((0, 100)),
+                                       value=0xe004, description="Red value -- only works if colour-mode is set to 3", ),
+            "rgb-green": MonitorProperty(name="rgb-green", range=tuple((0, 100)), value=0xe005,
+                                         description="Green value -- only works if colour-mode is set to 3", ),
+            "rgb-blue": MonitorProperty(name="rgb-blue", range=tuple((0, 100)), value=0xe006,
+                                        description="Blue value -- only works if colour-mode is set to 3", ),
         }
 
     @staticmethod
@@ -102,13 +55,14 @@ class Monitor:
         # +1 for Null byte in the header
         request_size = 192 + 1
         header_size = 0x40 + 1
-
+        assert property_value in monitor_property.range, \
+            f'Illegal value {property_value}, legal values: {monitor_property.range}'
         # Buffer needs to start with a null byte
         buffer = [0x00]
         # Request header
-        buffer += [0x40, 0xC6]
+        buffer += [0x40, 0xc6]
         buffer += [0x00] * 4
-        buffer += [0x20, 0x00, 0x6E, 0x00, 0x80]
+        buffer += [0x20, 0x00, 0x6e, 0x00, 0x80]
 
         # preamble needs this to be set up
         msg = [monitor_property.value >> 8] if monitor_property.value > 0xFF else []
@@ -121,7 +75,7 @@ class Monitor:
 
         buffer += preamble
         buffer += msg
-        buffer += [0x00] * (request_size - len(buffer))
+        buffer += ([0x00] * (request_size - len(buffer)))
         return bytes(buffer)
 
     def set_property(self, property_name: str, property_value: int):
@@ -131,50 +85,27 @@ class Monitor:
         :param property_value: The value to set the property to
         :return: Number of bytes written to the hid device
         """
+        assert property_name in self.configurable_properties, \
+            f"Invalid property {property_name}, " \
+            f"valid options: {list(self.configurable_properties.keys())}"
 
         prop = self.configurable_properties[property_name]
+        assert property_value in prop.range, f'{property_value} not in {prop.name}\'s legal value range.\n' \
+                                             f'The legal value range is: {prop.range}'
         with hid.Device(self.VID, self.PID) as device:
             return device.write(Monitor._build_request(prop, property_value))
 
 
-def ranged_int(min: int, max: int):
-    """
-    Returns a function, which transforms its argument into an integer
-    and checks if the result is in the given bounds.
-    :param min: Minimum value
-    :param max: Maximum value
-    :return: Function to used in ArgumentParser
-    """
-
-    def func(arg: str) -> int:
-        try:
-            x = int(arg)
-            if x < min or x > max:
-                raise argparse.ArgumentTypeError(f"must be within range [{min}, {max}]")
-            return x
-        except ValueError:
-            raise argparse.ArgumentTypeError(f"must be a valid integer.")
-
-    return func
-
-
 def main():
     monitor = Monitor()
-    parser = argparse.ArgumentParser(description="Set properties of gigabyte monitors.")
-
-    # Generate options from configurable properties
-    for prop in monitor.configurable_properties.values():
-        name = (f"-{prop.abbr}", f"--{prop.name}") if prop.abbr is not None else (f"--{prop.name}",)
-        parser.add_argument(*name, type=ranged_int(*prop.range), metavar=f"[{prop.range[0]}-{prop.range[1]}]")
+    parser = argparse.ArgumentParser(description='Set monitor property.')
+    parser.add_argument('-p', '--property',
+                        required=True, help='Property to set', choices=monitor.configurable_properties.keys())
+    parser.add_argument('-v', '--value',
+                        required=True, help='Monitor property value', metavar="[0-255]",
+                        type=int)
     args = parser.parse_args()
-
-    # Set property for each supplied argument
-    for name, value in vars(args).items():
-        if value is not None:
-            monitor.set_property(name, value)
-
-            # Some sort of delay was required in my setup, could maybe be tweaked
-            time.sleep(0.2)
+    monitor.set_property(args.property, args.value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hey! First of all, thank you for your work.
I tried using the script with my M34WQ, but unfortunately, only the KVM switch worked.

Using Sidekick and wireshark, I found out that in my case, Sidekick only sends the property hex code in two bytes if necessary. I hope that this also works for your display, otherwise simply reject the request.